### PR TITLE
query lugares usuario

### DIFF
--- a/Proyecto/lieou/src/app/explorer/page.tsx
+++ b/Proyecto/lieou/src/app/explorer/page.tsx
@@ -1,10 +1,13 @@
+
 "use client";
 
 import * as React from "react";
 import { SwipeDeck } from "./-components/SwipeDeck";
-import { mockPlaces, type Place } from "@/lib/mockPlaces";
+import { useRecommendedPlaces } from "@/hooks/useRecommendedPlaces";
+import { type Place } from "@/lib/mockPlaces";
 
-export default function PersonPage() {
+export default function ExplorerPage() {
+  const { data: places, isLoading, error } = useRecommendedPlaces();
   const [, setSaved] = React.useState<Place[]>([]);
 
   const handleSave = (place: Place) => {
@@ -15,5 +18,9 @@ export default function PersonPage() {
     // no-op for mock; could track discards if desired
   };
 
-  return <SwipeDeck places={mockPlaces} onSave={handleSave} onDiscard={handleDiscard} />;
+  if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>Error loading places</div>;
+  if (!places || places.length === 0) return <div>No places available</div>;
+
+  return <SwipeDeck places={places} onSave={handleSave} onDiscard={handleDiscard} />;
 }

--- a/Proyecto/lieou/src/hooks/useRecommendedPlaces.ts
+++ b/Proyecto/lieou/src/hooks/useRecommendedPlaces.ts
@@ -1,0 +1,7 @@
+// src/hooks/useRecommendedPlaces.ts
+import { useQuery } from "@tanstack/react-query";
+import { getRecommendedOptions } from "@/data-access/places";
+
+export const useRecommendedPlaces = () => {
+  return useQuery(getRecommendedOptions);
+};

--- a/Proyecto/lieou/src/server/repositories/place.ts
+++ b/Proyecto/lieou/src/server/repositories/place.ts
@@ -52,6 +52,17 @@ export class PlaceRepository extends Effect.Service<PlaceRepository>()(
           })
         ),
 
+        findRecommended: (excludeBusinessId?: number) => DBQuery((db) =>
+          db.query.place.findMany({
+            with: { images: true }
+          })
+        ).pipe(
+          Effect.map(res => {
+            if (!excludeBusinessId) return res
+            return res.filter(p => p.business_id !== excludeBusinessId)
+          })
+        ),
+
         update: (id: number, payload: UpdatePlacePayload) => DBQuery((db) =>
           db
             .update(placeTable)

--- a/Proyecto/lieou/src/server/rpc/groups/place.rpcs.ts
+++ b/Proyecto/lieou/src/server/rpc/groups/place.rpcs.ts
@@ -18,6 +18,11 @@ export class PlaceRpcs extends RpcGroup.make(
     error: Unauthenticated,
     success: Schema.Array(PlaceSchema)
   }),
+  Rpc.make("GetRecommended", {
+    payload: Schema.Void,
+    error: Unauthenticated,
+    success: Schema.Array(PlaceSchema)
+  }),
   Rpc.make("GetById", {
     payload: Schema.Struct({ id: Schema.Number }),
     error: Schema.Union(Unauthenticated, PlaceNotFound),

--- a/Proyecto/lieou/src/server/rpc/handlers/place.handler.ts
+++ b/Proyecto/lieou/src/server/rpc/handlers/place.handler.ts
@@ -11,6 +11,7 @@ export const PlaceHandlersLive = PlaceRpcs.toLayer(
 
     return {
       PlaceCreate: (payload) => placeService.create(payload),
+      PlaceGetRecommended: () => placeService.getRecommended(),
       PlaceGetMyPlaces: () => placeService.getMyPlaces(),
       PlaceGetById: (payload) => placeService.getById(payload.id)
     }

--- a/Proyecto/lieou/src/server/services/place.ts
+++ b/Proyecto/lieou/src/server/services/place.ts
@@ -74,6 +74,17 @@ export class PlaceService extends Effect.Service<PlaceService>()(
 
           return place
         })
+        ,
+
+        getRecommended: () => Effect.gen(function*(){
+          const currentUser = yield* authRequired
+
+          // Try to resolve database user id; if not found we'll just return public places
+          const dbUser = yield* userRepo.findByClerkId(currentUser.user.id)
+          const excludeBusinessId = dbUser ? dbUser.id : undefined
+
+          return yield* placeRepo.findRecommended(excludeBusinessId)
+        })
       }
 
     }),


### PR DESCRIPTION
Este cambio elimina los datos estáticos (mocks) de la página de Explorer para mostrar datos reales.